### PR TITLE
Fix add contact validations

### DIFF
--- a/lib/epi_contacts/contact.ex
+++ b/lib/epi_contacts/contact.ex
@@ -24,7 +24,19 @@ defmodule EpiContacts.Contact do
 
   def change(contact, attrs, patient_case \\ nil) do
     contact
-    |> cast(attrs, [
+    |> changeset(attrs)
+    |> validate_required([:first_name, :last_name])
+    |> validate_contact_location()
+    |> validate_relationship()
+    |> validate_primary_language()
+    |> validate_exposure(patient_case)
+    |> validate_required([:phone, :contact_location, :primary_language, :exposed_on])
+    |> validate_email_format(:email)
+    |> validate_phone_format(:phone)
+  end
+
+  def changeset(contact, attrs) do
+    cast(contact, attrs, [
       :phone,
       :email,
       :is_minor,
@@ -35,14 +47,6 @@ defmodule EpiContacts.Contact do
       :primary_language,
       :exposed_on
     ])
-    |> validate_required([:first_name, :last_name])
-    |> validate_contact_location()
-    |> validate_relationship()
-    |> validate_primary_language()
-    |> validate_exposure(patient_case)
-    |> validate_required([:phone, :contact_location, :primary_language, :exposed_on])
-    |> validate_email_format(:email)
-    |> validate_phone_format(:phone)
   end
 
   def initials(contact) do

--- a/lib/epi_contacts/contacts.ex
+++ b/lib/epi_contacts/contacts.ex
@@ -7,28 +7,35 @@ defmodule EpiContacts.Contacts do
   alias EpiContacts.PatientCase
 
   def submit_contacts(contacts, patient_case) do
+    enqueue_contacts(contacts, patient_case)
+    log_contacts_submitted(patient_case, contacts)
+  end
+
+  defp analytics_reporter, do: Application.get_env(:epi_contacts, :analytics_reporter)
+
+  defp enqueue_contacts(contacts, patient_case) do
+    case_id = PatientCase.case_id(patient_case)
+    domain = PatientCase.domain(patient_case)
+    ts = DateTime.utc_now() |> DateTime.to_unix() |> to_string()
+    batch_id = PatientCase.transaction_id(patient_case) <> "-" <> ts
+
+    contacts
+    |> Enum.map(&%{contact: &1, patient_case: patient_case, domain: domain, case_id: case_id})
+    |> EpiContacts.PostContactsBatch.new_batch(batch_id: batch_id)
+    |> Oban.insert_all()
+  end
+
+  defp log_contacts_submitted(patient_case, contacts) do
     number_of_contacts = length(contacts)
+    case_id = PatientCase.case_id(patient_case)
+    domain = PatientCase.domain(patient_case)
 
-    Logger.info("submit_contacts", %{number_of_contacts: number_of_contacts})
-
-    enqueue_contacts(%{contacts: contacts, patient_case: patient_case})
+    Logger.info("submit_contacts", %{number_of_contacts: number_of_contacts, case_id: case_id, domain: domain})
 
     analytics_reporter().report_contacts_submission(
       contacts_count: number_of_contacts,
       patient_case: patient_case,
       timestamp: DateTime.utc_now()
     )
-  end
-
-  defp analytics_reporter, do: Application.get_env(:epi_contacts, :analytics_reporter)
-
-  defp enqueue_contacts(%{contacts: contacts, patient_case: patient_case}) do
-    ts = DateTime.utc_now() |> DateTime.to_unix() |> to_string()
-    batch_id = PatientCase.transaction_id(patient_case) <> "-" <> ts
-
-    contacts
-    |> Enum.map(&%{contact: &1, patient_case: patient_case})
-    |> EpiContacts.PostContactsBatch.new_batch(batch_id: batch_id)
-    |> Oban.insert_all()
   end
 end

--- a/lib/epi_contacts/languages.ex
+++ b/lib/epi_contacts/languages.ex
@@ -2,10 +2,13 @@ defmodule EpiContacts.Languages do
   @moduledoc false
 
   import EpiContacts.Gettext
-  import EpiContacts.Utils, only: [collect_first_elements: 1]
+  import EpiContacts.Utils
 
   @spec languages() :: list(binary())
   def languages, do: options() |> collect_first_elements()
+
+  @spec values() :: list(binary())
+  def values, do: options() |> collect_second_elements()
 
   @spec options() :: list({binary(), binary()})
   def options,

--- a/lib/epi_contacts/locations.ex
+++ b/lib/epi_contacts/locations.ex
@@ -2,11 +2,14 @@ defmodule EpiContacts.Locations do
   @moduledoc false
 
   import EpiContacts.Gettext
-  import EpiContacts.Utils, only: [collect_first_elements: 1]
+  import EpiContacts.Utils
 
   @spec locations() :: list(binary())
   def locations,
     do: options() |> collect_first_elements()
+
+  @spec values() :: list(binary())
+  def values, do: options() |> collect_second_elements()
 
   @spec options() :: list({binary(), binary()})
   def options,

--- a/lib/epi_contacts/relationships.ex
+++ b/lib/epi_contacts/relationships.ex
@@ -2,10 +2,13 @@ defmodule EpiContacts.Relationships do
   @moduledoc false
 
   import EpiContacts.Gettext
-  import EpiContacts.Utils, only: [collect_first_elements: 1]
+  import EpiContacts.Utils
 
   @spec relationships() :: list(binary())
   def relationships, do: options() |> collect_first_elements()
+
+  @spec values() :: list(binary())
+  def values, do: options() |> collect_second_elements()
 
   @spec options() :: list({binary(), binary()})
   def options,

--- a/lib/epi_contacts/utils.ex
+++ b/lib/epi_contacts/utils.ex
@@ -7,4 +7,9 @@ defmodule EpiContacts.Utils do
   def collect_first_elements(list) do
     Enum.map(list, &elem(&1, 0))
   end
+
+  @spec collect_second_elements(list()) :: list()
+  def collect_second_elements(list) do
+    Enum.map(list, &elem(&1, 1))
+  end
 end

--- a/lib/epi_contacts/validators.ex
+++ b/lib/epi_contacts/validators.ex
@@ -25,7 +25,7 @@ defmodule EpiContacts.Validators do
     if changeset |> get_field(:contact_location) |> is_nil() do
       put_change(changeset, :contact_location, "unknown")
     else
-      validate_inclusion(changeset, :contact_location, EpiContacts.Locations.locations())
+      validate_inclusion(changeset, :contact_location, EpiContacts.Locations.values())
     end
   end
 
@@ -33,7 +33,7 @@ defmodule EpiContacts.Validators do
     if changeset |> get_field(:relationship) |> is_nil() do
       put_change(changeset, :relationship, "na")
     else
-      validate_inclusion(changeset, :relationship, EpiContacts.Relationships.relationships())
+      validate_inclusion(changeset, :relationship, EpiContacts.Relationships.values())
     end
   end
 
@@ -41,7 +41,7 @@ defmodule EpiContacts.Validators do
     if changeset |> get_field(:primary_language) |> is_nil() do
       put_change(changeset, :primary_language, "other")
     else
-      validate_inclusion(changeset, :primary_language, EpiContacts.Languages.languages())
+      validate_inclusion(changeset, :primary_language, EpiContacts.Languages.values())
     end
   end
 

--- a/lib/epi_contacts_web/templates/questionnaire/add_contact_component.html.leex
+++ b/lib/epi_contacts_web/templates/questionnaire/add_contact_component.html.leex
@@ -32,16 +32,19 @@
   <div class="dropdown-group">
     <h4><%= gettext("What is their relationship to you?") %></h4>
     <%= select f, :relationship, EpiContacts.Relationships.options(), prompt: gettext("Select one") %>
+    <%= error_tag f, :relationship %>
   </div>
 
   <div class="dropdown-group">
     <h4><%= gettext("Where did you come in contact?") %></h4>
     <%= select f, :contact_location, EpiContacts.Locations.options(), prompt: gettext("Select one") %>
+    <%= error_tag f, :contact_location %>
   </div>
 
   <div class="dropdown-group">
     <h4><%= gettext("What is their primary language?") %></h4>
     <%= select f, :primary_language, EpiContacts.Languages.options(), prompt: gettext("Select one") %>
+    <%= error_tag f, :primary_language %>
   </div>
 
   <div class="button-group">

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -424,7 +424,7 @@ msgstr ""
 #, elixir-format
 #: lib/epi_contacts_web/views/questionnaire_view.ex:127
 msgid "Who else have you seen"
-msgstr "Who else did you see who was less than 6 feet away for more than 10 minutes %{infectious_period} to today?"
+msgstr "Who else did you see who was less than 6 feet away for more than 10 minutes"
 
 #, elixir-format
 #: lib/epi_contacts_web/views/questionnaire_view.ex:121

--- a/test/epi_contacts/contacts_test.exs
+++ b/test/epi_contacts/contacts_test.exs
@@ -3,9 +3,7 @@ defmodule EpiContacts.ContactsTest do
 
   import Mox
 
-  alias EpiContacts.Contact
-  alias EpiContacts.Contacts
-  alias EpiContacts.PostContactsBatch
+  alias EpiContacts.{Contact, Contacts, PatientCase, PostContactsBatch}
 
   setup :verify_on_exit!
 
@@ -33,6 +31,8 @@ defmodule EpiContacts.ContactsTest do
 
     test "enqueues a job to post the contacts to commcare", %{contacts: contacts, patient_case: patient_case} do
       stub_analytics_reporter()
+      case_id = PatientCase.case_id(patient_case)
+      domain = PatientCase.domain(patient_case)
 
       Contacts.submit_contacts(contacts, patient_case)
 
@@ -42,14 +42,18 @@ defmodule EpiContacts.ContactsTest do
                  args: %{
                    "batch_id" => batch_id,
                    "contact" => %{"first_name" => "Jane"},
-                   "patient_case" => patient_case
+                   "patient_case" => patient_case,
+                   "case_id" => ^case_id,
+                   "domain" => ^domain
                  }
                },
                %{
                  args: %{
                    "batch_id" => _,
                    "contact" => %{"first_name" => "Bob"},
-                   "patient_case" => patient_case
+                   "patient_case" => patient_case,
+                   "case_id" => ^case_id,
+                   "domain" => ^domain
                  }
                }
              ] = all_enqueued(worker: PostContactsBatch)

--- a/test/epi_contacts/utils_test.exs
+++ b/test/epi_contacts/utils_test.exs
@@ -7,9 +7,21 @@ defmodule EpiContacts.UtilsTest do
     test "returns an empty list when given an empty list" do
       assert Utils.collect_first_elements([]) == []
     end
+
     test "returns list of first elements of sub-collections" do
       list = [{"a", 1}, {"b", 2}]
       assert Utils.collect_first_elements(list) == ["a", "b"]
+    end
+  end
+
+  describe "collect_second_elements/1" do
+    test "returns an empty list when given an empty list" do
+      assert Utils.collect_second_elements([]) == []
+    end
+
+    test "returns list of second elements of sub-collections" do
+      list = [{"a", 1}, {"b", 2}]
+      assert Utils.collect_second_elements(list) == [1, 2]
     end
   end
 end

--- a/test/epi_contacts/validators_test.exs
+++ b/test/epi_contacts/validators_test.exs
@@ -1,0 +1,88 @@
+defmodule EpiContacts.ValidatorsTest do
+  use EpiContacts.DataCase, async: true
+
+  import Ecto.Changeset
+
+  alias EpiContacts.{
+    Contact,
+    Languages,
+    Locations,
+    Relationships,
+    Validators
+  }
+
+  describe "validate_contact_location/1" do
+    test "puts unknown if absent" do
+      assert_field_default(:validate_contact_location, :contact_location, "unknown")
+    end
+
+    test "adds error if it's an invalid value" do
+      assert_error_with_invalid_option(:validate_contact_location, :contact_location, %{contact_location: "Portland"})
+    end
+
+    test "checks if it's a valid value" do
+      assert_valid_value(:validate_contact_location, :contact_location, Locations)
+    end
+  end
+
+  describe "validate_primary_language/1" do
+    test "puts unknown if absent" do
+      assert_field_default(:validate_primary_language, :primary_language, "other")
+    end
+
+    test "adds error if it's an invalid value" do
+      assert_error_with_invalid_option(:validate_primary_language, :primary_language, %{
+        primary_language: "Ancient Greek"
+      })
+    end
+
+    test "checks if it's a valid value" do
+      assert_valid_value(:validate_primary_language, :primary_language, Languages)
+    end
+  end
+
+  describe "validate_relationship/1" do
+    test "puts unknown if absent" do
+      assert_field_default(:validate_relationship, :relationship, "na")
+    end
+
+    test "adds error if it's an invalid value" do
+      assert_error_with_invalid_option(:validate_relationship, :relationship, %{relationship: "long lost cousin"})
+    end
+
+    test "checks if it's a valid value" do
+      assert_valid_value(:validate_relationship, :relationship, Relationships)
+    end
+  end
+
+  defp assert_valid_value(f, field, mod) do
+    value = mod.values() |> Enum.take_random(1)
+    changeset = Contact.changeset(%Contact{}, %{field => value})
+    changeset = apply(Validators, f, [changeset])
+
+    assert_no_errors_on(changeset, field)
+  end
+
+  defp assert_field_default(f, field, value) do
+    changeset = Contact.changeset(%Contact{}, %{})
+    changeset = apply(Validators, f, [changeset])
+    assert get_field(changeset, field) == value
+  end
+
+  defp assert_error_with_invalid_option(f, field, attrs) do
+    changeset = Contact.changeset(%Contact{}, attrs)
+    changeset = apply(Validators, f, [changeset])
+
+    refute changeset.valid?
+
+    assert_errors_on(changeset, field)
+  end
+
+  defp assert_no_errors_on(%Ecto.Changeset{} = changeset, key) do
+    !assert_errors_on(changeset, key)
+  end
+
+  defp assert_errors_on(%Ecto.Changeset{errors: errors}, key) do
+    errors |> Keyword.keys() |> Enum.member?(key) |> assert()
+  end
+end


### PR DESCRIPTION
There was a bug introduced when refactoring which (before the repo
split) where previously values were being used. The change used the
keys, not the values.