### PR TITLE
CommCare API interface improvements

### DIFF
--- a/lib/epi_contacts/commcare/api.ex
+++ b/lib/epi_contacts/commcare/api.ex
@@ -2,8 +2,8 @@ defmodule EpiContacts.Commcare.Api do
   @moduledoc """
   This module provides an interface to the Commcare API.
   """
-  @timeout 10_000
-  @recv_timeout 30_000
+  @timeout 20_000
+  @recv_timeout 45_000
 
   def get_case(case_id, domain) do
     commcare_api_case_url(domain, case_id)

--- a/lib/epi_contacts/commcare/api.ex
+++ b/lib/epi_contacts/commcare/api.ex
@@ -2,6 +2,9 @@ defmodule EpiContacts.Commcare.Api do
   @moduledoc """
   This module provides an interface to the Commcare API.
   """
+
+  require Logger
+
   @timeout 20_000
   @recv_timeout 45_000
 
@@ -59,8 +62,6 @@ defmodule EpiContacts.Commcare.Api do
   end
 
   defp parse_response({:ok, %{status_code: 201, body: body}} = response) do
-    require Logger
-
     if post_success?(body) do
       :ok
     else
@@ -74,5 +75,6 @@ defmodule EpiContacts.Commcare.Api do
   defp parse_response({:ok, %{status_code: 401}}), do: {:error, :commcare_authorization_error}
   defp parse_response({:ok, %{status_code: 403}}), do: {:error, :commcare_forbidden}
   defp parse_response({:ok, %{status_code: 404}}), do: {:error, :not_found}
+  defp parse_response({:error, %HTTPoison.Error{reason: :timeout}}), do: {:error, :timeout}
   defp parse_response({:error, _} = response), do: response
 end

--- a/lib/epi_contacts/commcare/client.ex
+++ b/lib/epi_contacts/commcare/client.ex
@@ -61,6 +61,8 @@ defmodule EpiContacts.Commcare.Client do
   def format_date(date), do: Timex.format!(date, "{YYYY}-{M}-{D}")
 
   def build_contact(patient_case, contact, opts \\ []) do
+    case_id = opts[:case_id] || UUID.uuid4()
+
     case_data = %{
       first_name: Contact.first_name(contact),
       last_name: Contact.last_name(contact),
@@ -111,7 +113,7 @@ defmodule EpiContacts.Commcare.Client do
       update: case_data,
       index: [{:parent, parent_case_metadata, PatientCase.case_id(patient_case)}]
     ]
-    |> build(UUID.uuid4(), opts)
+    |> build(case_id, opts)
   end
 
   def post_contact(patient_case, contact, envelope_id) do

--- a/lib/epi_contacts/post_contact_worker.ex
+++ b/lib/epi_contacts/post_contact_worker.ex
@@ -11,10 +11,18 @@ defmodule EpiContacts.PostContactWorker do
 
   @impl Oban.Worker
   def perform(%_{
-        args: %{"patient_case" => patient_case, "contact" => contact, "envelope_id" => envelope_id},
+        args: %{
+          "patient_case" => patient_case,
+          "contact" => contact,
+          "envelope_id" => envelope_id,
+          "case_id" => case_id
+        },
         attempt: attempt
       }) do
-    case CommcareClient.post_contact(patient_case, Contact.from_string_map(contact), envelope_id: envelope_id) do
+    case CommcareClient.post_contact(patient_case, Contact.from_string_map(contact),
+           case_id: case_id,
+           envelope_id: envelope_id
+         ) do
       {:error, :timeout} ->
         {:snooze, (1 + attempt) * 60}
 
@@ -26,9 +34,10 @@ defmodule EpiContacts.PostContactWorker do
   def enqueue_contacts(%{contacts: contacts, patient_case: patient_case}) do
     for contact <- contacts do
       contact = %Contact{contact | contact_id: PatientCase.generate_contact_id(patient_case)}
+      case_id = Ecto.UUID.generate()
       envelope_id = Ecto.UUID.generate()
 
-      %{patient_case: patient_case, contact: contact, envelope_id: envelope_id}
+      %{patient_case: patient_case, contact: contact, envelope_id: envelope_id, case_id: case_id}
       |> __MODULE__.new()
       |> Oban.insert()
       |> log_insert(contact)

--- a/test/epi_contacts/commcare/api_test.exs
+++ b/test/epi_contacts/commcare/api_test.exs
@@ -68,14 +68,24 @@ defmodule EpiContacts.Commcare.ApiTest do
                Api.post_case("some data", @test_domain)
     end
 
+    test "with timeout" do
+      Mox.expect(EpiContacts.HTTPoisonMock, :post, 1, fn url, body, _headers, _opt ->
+        assert url == "https://www.commcarehq.org/a/#{@test_domain}/receiver/"
+        assert body == "some data"
+        {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
+      end)
+
+      assert {:error, :timeout} == Api.post_case("some data", @test_domain)
+    end
+
     test "with error response, returns error tuple containing http error response details" do
       Mox.expect(EpiContacts.HTTPoisonMock, :post, 1, fn url, body, _headers, _opt ->
         assert url == "https://www.commcarehq.org/a/#{@test_domain}/receiver/"
         assert body == "some data"
-        {:error, :http_timeout}
+        {:error, :some_error}
       end)
 
-      assert {:error, :http_timeout} == Api.post_case("some data", @test_domain)
+      assert {:error, :some_error} == Api.post_case("some data", @test_domain)
     end
   end
 

--- a/test/epi_contacts/post_contact_worker_test.exs
+++ b/test/epi_contacts/post_contact_worker_test.exs
@@ -34,7 +34,8 @@ defmodule EpiContacts.PostContactWorkerTest do
       "first_name" => "Contact 1",
       "last_name" => "last name",
       "phone" => "123-456-7890"
-    }
+    },
+    "envelope_id" => "some-uuid"
   }
 
   describe "enqueue_contacts" do

--- a/test/epi_contacts/post_contact_worker_test.exs
+++ b/test/epi_contacts/post_contact_worker_test.exs
@@ -35,7 +35,8 @@ defmodule EpiContacts.PostContactWorkerTest do
       "last_name" => "last name",
       "phone" => "123-456-7890"
     },
-    "envelope_id" => "some-uuid"
+    "envelope_id" => "some-uuid",
+    "case_id" => "some-other-uuid"
   }
 
   describe "enqueue_contacts" do


### PR DESCRIPTION
In order to avoid, lessen, and gracefully handle retries when creating contacts, we need to:
* lengthen the timeouts
* snooze the worker instead of failing in the timeout scenario (with a healthy backoff)
* add the `meta` node so the `create` operation is processed as idempotent.